### PR TITLE
although <some> syscalls are supported by emscripten, this is not wha…

### DIFF
--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -1248,6 +1248,7 @@ test_specific_config_settings(int test_conns, int test_buffs)
 	#if defined(__EMSCRIPTEN__)
 	// emscripten supports (some?) syscalls, but that's not actually what we want, because we want to remain inside the wasm sandbox
 	// so just return a dummy value until we decide how to handle syscalls.
+	// TODO: https://github.com/electric-sql/pglite/issues/798
 	status = 123;
 	#else
 	status = system(cmd.data);

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -1245,7 +1245,13 @@ test_specific_config_settings(int test_conns, int test_buffs)
 					  DEVNULL, DEVNULL);
 
 	fflush(NULL);
+	#if defined(__EMSCRIPTEN__)
+	// emscripten supports (some?) syscalls, but that's not actually what we want, because we want to remain inside the wasm sandbox
+	// so just return a dummy value until we decide how to handle syscalls.
+	status = 123;
+	#else
 	status = system(cmd.data);
+	#endif // #if defined(__EMSCRIPTEN__)
 
 	termPQExpBuffer(&cmd);
 


### PR DESCRIPTION
although <some> syscalls are supported by emscripten, this is not what we (always) want. in this particular case, initdb is querying the server configuration by executing postgres with various parameters. when running on node, the calls end up trying to execute on the OS, which leads to a series of errors and undesirable behavior. instead, these syscalls should remain inside the wasm sandbox somehow. until we decide on a proper way to do this, the initdb querying of postgres server configs will just fail (which is the case anyhow atm).