### PR TITLE
Added backend for pgTap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "pglite/pgvector"]
 	path = pglite/vector
 	url = https://github.com/pgvector/pgvector.git
+[submodule "pglite/pgtap"]
+	path = pglite/pgtap
+	url = https://github.com/theory/pgtap.git

--- a/pglite/Makefile
+++ b/pglite/Makefile
@@ -5,7 +5,8 @@ include $(top_builddir)/src/Makefile.global
 
 SUBDIRS = \
 		pg_ivm \
-		vector
+		vector \
+		pgtap
 
 prefix ?= /install/pglite
 EXTENSIONS_BUILD_ROOT := /tmp/extensions/build


### PR DESCRIPTION
Backend steps to add a new extension (happy path):

`$ cd pglite`
`$ git submodule add https://github.com/theory/pgtap.git`

Add the folder to the `pglite/Makefile`:

```
SUBDIRS = \
		pg_ivm \
		vector \
		pgtap
```