### PR TITLE
Reduce Postgis shared library size to <8mb

### DIFF
--- a/pglite/build-postgis.sh
+++ b/pglite/build-postgis.sh
@@ -12,9 +12,11 @@ PROJ_VERSION=9.7.0 LDFLAGS="-L/install/libs/lib" CFLAGS="${PGLITE_CFLAGS}" CXXFL
 # touch ./loader/pgsql2shp.wasm
 emmake make raster-sql || true
 # these flags are used in pgxs.mk (postgresql extension makefile) and passed to the build process of that extension
-emmake make LDFLAGS_SL="-sWASM_BIGINT -sSIDE_MODULE=1 -fexceptions -Wl,--whole-archive -lstdc++ -lsqlite3 -lgeos -Wl,--no-whole-archive" \
-CFLAGS_SL="-fexceptions -sWASM_BIGINT" \
-CXXFLAGS_SL="-fexceptions -sWASM_BIGINT" -j || { echo 'emmake make postgis failed' ; exit 442; }
+emmake make LDFLAGS_SL="-sWASM_BIGINT -sSIDE_MODULE=1 -fexceptions -Wl,--whole-archive -lgeos_c -Wl,--no-whole-archive -lstdc++ -lsqlite3 -lgeos -flto" \
+CFLAGS_SL="-fexceptions -sWASM_BIGINT -Oz -flto -ffunction-sections -fdata-sections" \
+CXXFLAGS_SL="-fexceptions -sWASM_BIGINT -Oz -flto -ffunction-sections -fdata-sections" -j || { echo 'emmake make postgis failed' ; exit 442; }
+/emsdk/upstream/bin/wasm-opt -Oz postgis/postgis-3.so -o postgis/postgis-3.opt.so || { echo 'wasm-opt postgis failed' ; exit 443; }
+mv postgis/postgis-3.opt.so postgis/postgis-3.so
 # emmake make PG_LDFLAGS="-L/install/libs/lib -lpgport -lpgcommon -sSIDE_MODULE=1" -j
 
 cd ..


### PR DESCRIPTION
This aims to resolve the outstanding issue ( https://github.com/electric-sql/pglite/pull/807#issuecomment-3740601937 ) on https://github.com/electric-sql/pglite/pull/807 that the Postgis library is over 8mb and Chrome has a hard 8mb limit for WASM modules.

This is achieved by:
* Moving stdc++, sqlite3, geos libs out of `--whole-archive` (saves ~250k bytes)
* Adding `-flto` for link-time optimisation (saves ~11k bytes)
* Adding `-Oz` (saves ~45k bytes)
* Adding a `wasm-opt` step (saves ~30k bytes)

Brings it down in total to 8,370,885 bytes (8,388,608 limit).

This works locally for me in Chrome and seems to pass the test suite used on the above PR.

Performance-wise, the effects of `-Oz` seem neglible. I have not ran a extensive benchmark, but on a table with 20k points and 200 regions (w/ index) running a couple queries like `ST_DWithin`, `ST_Intersects`, etc. 5 times on the optimized and non-optimized versions, the differences are within 1-2% either direction.