### PR TITLE
Export register_label_provider

### DIFF
--- a/pglite/static/included.pglite.exports
+++ b/pglite/static/included.pglite.exports
@@ -507,6 +507,7 @@ readstoplist
 realloc
 realpath
 regclassin
+register_label_provider
 RegisterExtensibleNodeMethods
 RelationClose
 RelationGetIndexList


### PR DESCRIPTION
 Enables support for registering security label providers (https://github.com/electric-sql/pglite/issues/991)