### PR TITLE
Export pgoutput.so imports from the main wasm module to enable logical replication slots

### DIFF
--- a/src/backend/replication/pgoutput/Makefile
+++ b/src/backend/replication/pgoutput/Makefile
@@ -24,9 +24,27 @@ include $(top_srcdir)/src/Makefile.shlib
 
 install: all installdirs install-lib
 
+ifeq ($(PORTNAME), emscripten)
+# pgoutput.so is loaded at runtime as an emscripten side module, but unlike
+# pgxs-built extensions it is linked from src/backend, so its imports from the
+# core module are not collected automatically. Without this, symbols used only
+# by pgoutput (e.g. logicalrep_write_*) are dead-code-eliminated from the main
+# module (-sMAIN_MODULE=2) and logical decoding fails at runtime with a call
+# to an undefined table entry. Generate the .imports file here so the
+# pglite-exported-functions target keeps these symbols alive.
+install: install-imports
+
+.PHONY: install-imports
+install-imports: all
+	$(MKDIR_P) '$(DESTDIR)$(emscripten_extension_imports_dir)'
+	find . -name "*.o" -exec $(LLVM_NM) --undefined-only {} \; | awk '{print $$2}' | sed '/^$$/d' | sort -u > '$(NAME).undef.txt'
+	find . -type f \( -name "*.o" -o -name "*.so" \) -exec $(LLVM_NM) --defined-only {} \; | awk '$$2 ~ /^[TDB]$$/ {print $$3}' | sed '/^$$/d' | sort -u > '$(NAME).defs.txt'
+	comm -23 '$(NAME).undef.txt' '$(NAME).defs.txt' > '$(DESTDIR)$(emscripten_extension_imports_dir)/$(NAME).imports'
+endif
+
 installdirs: installdirs-lib
 
 uninstall: uninstall-lib
 
 clean distclean: clean-lib
-	rm -f $(OBJS)
+	rm -f $(OBJS) $(NAME).undef.txt $(NAME).defs.txt


### PR DESCRIPTION
## Problem

Logical replication slots don't work in PGlite (electric-sql/pglite#880). Even with `wal_level=logical`, consuming a slot crashes the session:

```sql
SELECT pg_create_logical_replication_slot('slot1', 'pgoutput'); -- works
SELECT * FROM pg_logical_slot_peek_binary_changes('slot1', NULL, NULL,
  'proto_version', '1', 'publication_names', 'pub1');
-- returns 0 rows, and every query afterwards silently returns nothing,
-- until the backend PANICs with "ERRORDATA_STACK_SIZE exceeded"
```

## Root cause

`pgoutput.so` is loaded at runtime as an emscripten side module, but unlike pgxs-built extensions (which generate a `.imports` file at install time that feeds `-sEXPORTED_FUNCTIONS` via the `pglite-exported-functions` target), it is linked from `src/backend/replication/pgoutput` via `Makefile.shlib`, so its imports were never collected.

With `-sMAIN_MODULE=2`, every symbol used *only* by pgoutput gets dead-code-eliminated from the main module — 46 functions in the current build, including `defGetStreamingMode`, all `logicalrep_write_*`, `GetRelationPublications`, `CacheRegisterRelSyncCallback`, etc. (verified by diffing `WebAssembly.Module.imports(pgoutput.so)` against `WebAssembly.Module.exports(pglite.wasm)`; `GOT.mem` resolves fully, only function imports are missing).

At runtime the first missing call happens inside pgoutput's startup callback, throws `TypeError: r is not a function` from an `invoke_*` trampoline, and the JS side swallows it, leaving the backend permanently corrupted.

## Fix

Generate `pgoutput.imports` at install time, using the same `llvm-nm` recipe as `pgxs.mk`, so the existing `pglite-exported-functions` target picks it up and the symbols survive DCE.

After rebuilding, all 46 previously-missing imports are exported from the main module and logical decoding with pgoutput works end-to-end (create/list/drop slots, peek/get binary changes, slot persistence across dump/load). Tests exercising this live in the companion PR to electric-sql/pglite, together with defaulting `wal_level=logical` and no longer swallowing unexpected WASM exceptions.

Fixes electric-sql/pglite#880

🤖 Generated with [Claude Code](https://claude.com/claude-code)
