### PR TITLE
backend: add pg_bigm for CJK full text search

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,6 @@
 [submodule "pglite/other_extensions/pgmq"]
 	path = pglite/other_extensions/pgmq
 	url = https://github.com/pgmq/pgmq
+[submodule "pglite/other_extensions/pg_bigm"]
+	path = pglite/other_extensions/pg_bigm
+	url = https://github.com/pgbigm/pg_bigm.git

--- a/pglite/other_extensions/Makefile
+++ b/pglite/other_extensions/Makefile
@@ -9,7 +9,14 @@ SUBDIRS = \
 		pg_uuidv7 \
 		pg_hashids \
 		pg_textsearch \
-		pgmq/pgmq-extension
+		pgmq/pgmq-extension \
+		pg_bigm
+
+# Every other extension here includes PGXS unconditionally. pg_bigm gates it
+# behind USE_PGXS and otherwise assumes it sits in the postgres tree as
+# contrib/pg_bigm, which resolves contrib-global.mk to a path that does not
+# exist from here. Set the flag for its build and its packaging step only.
+all-pg_bigm-recurse pg_bigm.tar.gz: export USE_PGXS = 1
 
 prefix ?= /pglite
 EXTENSIONS_BUILD_ROOT := /tmp/extensions/build


### PR DESCRIPTION
# Motivation

[pg_bigm](https://github.com/pgbigm/pg_bigm) is a community extension widely adopted in Asian market. It indexes text as 2-grams instead of pg_trgm's 3-grams. That is what makes `LIKE '%...%'` searches usable on Asian language texts (Chinese, Japanese and Korean), where search terms are commonly one or two characters long. 

# Solution

Adds pg_big to pglite/other_extensions so it is built and packaged alongside the other third-party extensions.

Every other extension here includes PGXS unconditionally. pg_bigm gates it behind USE_PGXS and otherwise assumes it lives in the postgres tree as contrib/pg_bigm, which resolves contrib-global.mk to a path that does not exist from other_extensions.

Rather than patch the submodule, the flag is set for its build and packaging targets only:
`all-pg_bigm-recurse pg_bigm.tar.gz: export USE_PGXS = 1`

Happy to take a different approach here if you would rather not special-case it.

I will open a PR on https://github.com/electric-sql/pglite side if accepted.

# Notes

- No new dependencies in pglite/builder/Dockerfile. pg_bigm is two C files with no external libraries.
- Builds clean against PG 18.3 with the pinned electricsql/pglite-builder:3.1.74-7.
- Output is dist/extensions/other/pg_bigm.tar.gz, 5.6 KB.
- pg_bigm is under the PostgreSQL License.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/electric-sql/codesmith/postgres-pglite/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788260437&installation_model_id=8736&pr_number=82&repository=electric-sql%2Fpostgres-pglite&return_to=https%3A%2F%2Fgithub.com%2Felectric-sql%2Fpostgres-pglite%2Fpull%2F82&signature=77b0bbff8d7e70be359481e40c36771e0cca215fa8c3532d6bcfe2f6cb4d683f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->