### PR TITLE
feat: Add pg_partman 5.5.0 as a SQL-only extension (NO_BGW)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,6 @@
 [submodule "pglite/other_extensions/pgmq"]
 	path = pglite/other_extensions/pgmq
 	url = https://github.com/pgmq/pgmq
+[submodule "pglite/other_extensions/pg_partman"]
+	path = pglite/other_extensions/pg_partman
+	url = https://github.com/pgpartman/pg_partman.git

--- a/pglite/other_extensions/Makefile
+++ b/pglite/other_extensions/Makefile
@@ -18,6 +18,11 @@ ARCHIVE_DIR := /pglite/extensions/other
 EXTENSIONS := $(SUBDIRS)
 EXTENSIONS += postgis
 
+# NOTE: pg_partman is deliberately not in SUBDIRS: its default target would compile the
+# background worker, which cannot run in WASM. It is built SQL-only via its own
+# dist rule below with NO_BGW=1 (which is an officially supported pg_partman build mode).
+EXTENSIONS += pg_partman
+
 # Default target: build tarballs for all contribs
 dist: $(addsuffix .tar.gz,$(EXTENSIONS))
 
@@ -45,6 +50,18 @@ age.tar.gz:
 	cd $(EXTENSIONS_BUILD_ROOT)/age/$(prefix) && \
 	files=$$(find . -type f -o -type l | sed 's|^\./||') && \
 	tar -czf $(ARCHIVE_DIR)/age.tar.gz $$files
+
+# pg_partman's core is pure SQL/PLpgSQL; NO_BGW=1 skips its background worker C module
+pg_partman.tar.gz:
+	@echo "=== Staging pg_partman (SQL-only, NO_BGW=1) ==="
+	rm -rf $(EXTENSIONS_BUILD_ROOT)/pg_partman
+	bash -c 'mkdir -p $(EXTENSIONS_BUILD_ROOT)/pg_partman/$(prefix)/{bin,lib,share/extension,share/doc,share/postgresql/extension}'
+	$(MAKE) -C pg_partman NO_BGW=1 install DESTDIR=$(EXTENSIONS_BUILD_ROOT)/pg_partman
+	@echo "=== Packaging pg_partman ==="
+	mkdir -p $(ARCHIVE_DIR)
+	cd $(EXTENSIONS_BUILD_ROOT)/pg_partman/$(prefix) && \
+	files=$$(find . -type f -o -type l | sed 's|^\./||') && \
+	tar -czf $(ARCHIVE_DIR)/pg_partman.tar.gz $$files
 
 dist-postgis:
 	@echo "=== Adding proj data to postgis archive ==="


### PR DESCRIPTION
[pg_partman](https://github.com/pgpartman/pg_partman) is a fairly popular extension for managing partitions in postgres. I wanted to add support for it to be used in pglite. 

pg_partman's core is pure SQL/PLpgSQL; the only C component is its background worker, which schedules `run_maintenance()` and cannot exist in single-process WASM. Upstream officially supports building without it via NO_BGW=1, so the extension is packaged SQL-only and maintenance is invoked by the embedding application instead.

The submodule is pinned at the v5.5.0 release tag. It is intentionally kept out of SUBDIRS so the recursive 'all' build never attempts to compile the background worker with emscripten; only the dist rule touches it.